### PR TITLE
Add option to ignore packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
         uses: ./
         with:
           changed_files: ${{ steps.match.outputs.filtered }}
-          ignorePackages: '["mock-workspace"]'
+          ignore_packages: '["mock-workspace"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,4 @@ jobs:
         uses: ./
         with:
           changed_files: ${{ steps.match.outputs.filtered }}
+          ignorePackages: '["mock-workspace"]'

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -30,8 +30,12 @@ describe('action', () => {
         case 'changed_files':
           return JSON.stringify([
             './packages/pkg1/file1.css',
-            './packages/pkgB/file2.tsx'
+            './packages/pkgB/file2.tsx',
+            './packages/pkgC/file3.ts', // should be ignored
+            './packages/pkg3/file4.ts' // should be ignored
           ])
+        case 'ignore_packages':
+          return JSON.stringify(['@owner/pkg3', '@owner/pkgC'])
         default:
           return ''
       }

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   ignore_packages:
     description: list of packages to ignore
     required: false
-    default: []
+    default: '[]'
 
 runs:
   using: node20

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
   changed_files:
     description: list of changed files
     required: true
+  ignore_packages:
+    description: list of packages to ignore
+    required: false
+    default: []
 
 runs:
   using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -10904,6 +10904,7 @@ async function run() {
     try {
         const { context } = github;
         const changedFiles = JSON.parse(core.getInput('changed_files'));
+        const ignorePackages = JSON.parse(core.getInput('ignore_packages'));
         if (!changedFiles.length) {
             core.info('No changed files found. Skipping.');
             return;
@@ -10917,7 +10918,9 @@ async function run() {
         //   a future enhancement would be to determine the package manager and use that
         const workspacesResult = await exec.getExecOutput(`yarn workspaces --json info`);
         const workspacesInfo = JSON.parse(JSON.parse(workspacesResult.stdout).data);
-        const workspaces = Object.keys(workspacesInfo).map(name => ({
+        const workspaces = Object.keys(workspacesInfo)
+            .filter(name => !ignorePackages.includes(name))
+            .map(name => ({
             name,
             ...workspacesInfo[name]
         }));

--- a/mock-workspace/fakechange
+++ b/mock-workspace/fakechange
@@ -1,0 +1,1 @@
+testing ignorePackages

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export async function run(): Promise<void> {
     const { context } = github
 
     const changedFiles = JSON.parse(core.getInput('changed_files'))
+    const ignorePackages = JSON.parse(core.getInput('ignore_packages'))
 
     if (!changedFiles.length) {
       core.info('No changed files found. Skipping.')
@@ -36,10 +37,12 @@ export async function run(): Promise<void> {
     )
 
     const workspacesInfo = JSON.parse(JSON.parse(workspacesResult.stdout).data)
-    const workspaces = Object.keys(workspacesInfo).map(name => ({
-      name,
-      ...workspacesInfo[name]
-    }))
+    const workspaces = Object.keys(workspacesInfo)
+      .filter(name => !ignorePackages.includes(name))
+      .map(name => ({
+        name,
+        ...workspacesInfo[name]
+      }))
     // get packages in changed directories
     iterFiles: for (const file of changedFiles) {
       // remove file name from path


### PR DESCRIPTION
Based on feedback from @jeremywiebe, we may not always want to rely on filtering out undesirable files/packages before this step.

I have added a boolean input to optionally ignore specified package names.

However, the problem that was encountered (the wrong package being included in filtered files) is more robustly addressed [here in the filtered-files action.](https://github.com/Khan/actions/pull/74).