### PR TITLE
Use the .node-version file to define node env for Github actions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: ".node-version"
           cache: yarn
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: ".node-version"
           cache: yarn
 
       - name: Install Dependencies

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,7 +27,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: ".node-version"
           cache: yarn
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary:

This repo's Github actions use the `setup-node` action and define the `node-version` within each action. We have a `.node-version` file that defines the version of Node to use for tooling, and the `setup-node` action understands how to use that file, so this PR migrates all Github actions to defer to `.node-version` for which Node to use. Less duplication.

Issue: "none"

## Test plan: